### PR TITLE
Enable MeshoptDecoder on GLTFLoader

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react'
-import { GLTFLoader, DRACOLoader } from 'three-stdlib'
+import { GLTFLoader, DRACOLoader, MeshoptDecoder } from 'three-stdlib'
 import parse from '@react-three/gltfjsx'
 import Nav from './nav'
 import Viewer from './viewer'
@@ -9,6 +9,7 @@ const gltfLoader = new GLTFLoader()
 const dracoloader = new DRACOLoader()
 dracoloader.setDecoderPath('https://www.gstatic.com/draco/v1/decoders/')
 gltfLoader.setDRACOLoader(dracoloader)
+gltfLoader.setMeshoptDecoder(MeshoptDecoder)
 
 const Result = (props) => {
   const [code, setCode] = useState()


### PR DESCRIPTION
Adds support for models that use meshopt compression (e.g. from [gltfpack](https://github.com/zeux/meshoptimizer/tree/master/gltf)).

This mirrors drei's support for meshopt compression in [useGLTF](https://github.com/pmndrs/drei/blob/e50a8498f174ad279d57a5ef67cc310d9c7b9d35/src/core/useGLTF.tsx#L14)