### PR TITLE
remove scene prop from Viewer

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -109,9 +109,7 @@ const Result = () => {
       ) : (
         <div className="grid grid-cols-5 h-full">
           {code && <Code>{code}</Code>}
-          <section className="h-full w-full col-span-2">
-            {scene && <Viewer scene={scene} {...config} {...preview} />}
-          </section>
+          <section className="h-full w-full col-span-2">{scene && <Viewer {...config} {...preview} />}</section>
         </div>
       )}
       <Leva hideTitleBar collapsed />


### PR DESCRIPTION
Hi. Love the website. Amazing resource for working with gltfjsx.

This change removes `scene` that is being passed to `Viewer` in result.js as the prop is unused with `Viewer` getting that state from zustand.

I noticed this while trying to track down another bug (?) in the auto-generated code that is causing some glitches in renders when copied over and used with drei `useGLTF`. I'll open a separate issue for that.