### PR TITLE
Update store.js draco unpkg url

### DIFF
--- a/utils/store.js
+++ b/utils/store.js
@@ -15,7 +15,7 @@ import { WebGLRenderer } from 'three'
 let gltfLoader
 if (typeof window !== 'undefined') {
   const THREE_PATH = `https://unpkg.com/three@0.${REVISION}.x`
-  const dracoloader = new DRACOLoader().setDecoderPath(`${THREE_PATH}/examples/js/libs/draco/gltf/`)
+  const dracoloader = new DRACOLoader().setDecoderPath(`${THREE_PATH}/examples/jsm/libs/draco/gltf/`)
   const ktx2Loader = new KTX2Loader().setTranscoderPath(`${THREE_PATH}/examples/js/libs/basis/`)
 
   gltfLoader = new GLTFLoader()


### PR DESCRIPTION
Latest few versions of three no longer have the non-jsm draco files.

<img width="870" alt="image" src="https://github.com/pmndrs/gltf-react-three/assets/6433887/92ca6030-5fba-4dea-8b25-04db7e7691dd">
