### PR TITLE
Added pathPrefix option to leva form and generated code

### DIFF
--- a/components/result.js
+++ b/components/result.js
@@ -22,6 +22,11 @@ const Result = () => {
     keepgroups: { value: false, label: 'keep groups', hint: 'Keep (empty) groups' },
     meta: { value: false, hint: 'Include metadata (as userData)' },
     precision: { value: 3, min: 1, max: 8, step: 1, hint: 'Number of fractional digits (default: 2)' },
+    pathPrefix: {
+      label: 'path prefix',
+      value: '',
+      hint: 'Prefix for all paths',
+    },
   }))
 
   const preview = useControls(

--- a/utils/store.js
+++ b/utils/store.js
@@ -23,7 +23,8 @@ const useStore = create((set, get) => ({
     saveAs(blob, `${fileName.split('.')[0]}.zip`)
   },
   generateScene: async (config) => {
-    const { fileName, buffers } = get()
+    const { fileName: rawFileName, buffers } = get()
+    const fileName = config.pathPrefix && config.pathPrefix !== '' ? `${config.pathPrefix}/${rawFileName}` : rawFileName
     let result
     if (buffers.size !== 1) {
       const loadingManager = new THREE.LoadingManager()


### PR DESCRIPTION
Reason for addition:
- I am using this tool for a game in Next.js right now. I have my models stored in a `models` foldder within my `public` folder. It would be helpful to state the path prefix in this tool directly instead of manually changing the pathnames after exporting each time.

Changes:
- in `components/result.js`
  - I added a `pathPrefix` option to config leva controls that allows the user to specify a path prefix that will be appended to the fileName.
- in `utils/store.js`
  - if, `pathPrefix` is undefined or empty: use `fileName`
  - else, use `pathPrefix` + `/` + `fileName`